### PR TITLE
Externalise the basic logging configuration.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,6 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ginlong-scraper.py ./
+COPY logging_config.ini ./
 
 CMD [ "python", "./ginlong-scraper.py" ]

--- a/ginlong-scraper.py
+++ b/ginlong-scraper.py
@@ -6,6 +6,7 @@ import datetime
 import time
 import os
 import logging
+import logging.config
 import schedule
 
 # Not all keys are avilable depending on your setup
@@ -247,15 +248,9 @@ def main():
 global next_run_yes
 
 get_loglevel = os.environ['LOG_LEVEL']
-loglevel = logging.INFO
-if get_loglevel.lower() == "info":
-    loglevel = logging.INFO
-elif get_loglevel.lower() == "error":
-    loglevel = logging.ERROR
-elif get_loglevel.lower() == "debug":
-    loglevel = logging.DEBUG
+loglevel = get_loglevel.upper()
 
-logging.basicConfig(level=loglevel, format='%(asctime)s %(levelname)s %(message)s')
+logging.config.fileConfig('logging_config.ini', defaults={'loglevel': loglevel})
 logging.info('Started ginlong-solis-scraper')
 
 schedule.every(5).minutes.at(':00').do(main).run()

--- a/logging_config.ini
+++ b/logging_config.ini
@@ -1,0 +1,21 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=stderr
+
+[formatters]
+keys=simpleFormatter
+
+[logger_root]
+level=DEBUG
+handlers=stderr
+
+[handler_stderr]
+class=StreamHandler
+level=%(loglevel)s
+formatter=simpleFormatter
+args=(sys.stderr,)
+
+[formatter_simpleFormatter]
+format=%(asctime)s %(levelname)s %(message)s


### PR DESCRIPTION
Refactor the existing use of basicConfig into an external configuration
file, to simplify local customisation.